### PR TITLE
fix(example): pytorch_example raise system error

### DIFF
--- a/advanced/pytorch-example/main.py
+++ b/advanced/pytorch-example/main.py
@@ -84,6 +84,7 @@ def train():
         torch.save(model.module.state_dict(), "mnist_model.pth")
         print("Model saved as mnist_model.pth")
 
+    dist.barrier()
     dist.destroy_process_group()
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the end, rank 0 will save ckpt, and other rank destory_process_group directly, this will cause rank 0 raise exception like
```
[rank6]:[E722 07:46:47.681877747 ProcessGroupNCCL.cpp:542] [Rank 6] Collective WorkNCCL(SeqNum=1184, OpType=ALLREDUCE, NumelIn=18816, NumelOut=18816, Timeout(ms)=600000) raised the following async exception: NCCL error: unhandled system error (run with NCCL_DEBUG=INFO for details), NCCL version 2.23.4
ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. 
Last error:
```

To solve it, we need all rank do destroy_process_group at same time.